### PR TITLE
Introduced Ticker browser and right-panel functionality

### DIFF
--- a/src/modal/pane.rs
+++ b/src/modal/pane.rs
@@ -17,6 +17,7 @@ pub fn stack<'a, Message>(
 where
     Message: Clone + 'a,
 {
+    // Draw the overlay on top of everything (pane + margins)
     iced::widget::stack![
         base.into(),
         mouse_area(

--- a/src/screen/dashboard.rs
+++ b/src/screen/dashboard.rs
@@ -25,7 +25,7 @@ use iced::{
     Element, Length, Subscription, Task, Vector,
     task::{Straw, sipper},
     widget::{
-        PaneGrid, center, container,
+        PaneGrid, center, container, row, button, responsive,
         pane_grid::{self, Configuration},
     },
 };
@@ -41,6 +41,12 @@ pub enum Message {
     Notification(Toast),
     LayoutFetchAll,
     RefreshStreams,
+    // Right-panel control & routing
+    OpenTickerBrowser,
+    OpenPaneSettings(window::Id, pane_grid::Pane),
+    CloseRightPanel,
+    TickerBrowser(tickers_table::Message),
+    ChangePaneChartType(window::Id, pane_grid::Pane, String),
     ChartRequestedFetch {
         window: window::Id,
         pane: pane_grid::Pane,
@@ -60,6 +66,8 @@ pub struct Dashboard {
     pub focus: Option<(window::Id, pane_grid::Pane)>,
     pub popout: HashMap<window::Id, (pane_grid::State<pane::State>, WindowSpec)>,
     pub streams: UniqueStreams,
+    right_panel: RightPanel,
+    active_ticker_browser: Option<(window::Id, pane_grid::Pane)>,
 }
 
 impl Default for Dashboard {
@@ -69,6 +77,8 @@ impl Default for Dashboard {
             focus: None,
             streams: UniqueStreams::default(),
             popout: HashMap::new(),
+            right_panel: RightPanel::Closed,
+            active_ticker_browser: None,
         }
     }
 }
@@ -82,6 +92,13 @@ pub enum Event {
         data: FetchedData,
         stream: StreamKind,
     },
+}
+
+// Right-side panel hosting either the Ticker Browser or per-pane Settings
+enum RightPanel {
+    Closed,
+    TickerBrowser(tickers_table::TickersTable),
+    Settings { window: window::Id, pane: pane_grid::Pane },
 }
 
 impl Dashboard {
@@ -129,6 +146,8 @@ impl Dashboard {
             focus: None,
             streams: UniqueStreams::default(),
             popout,
+            right_panel: RightPanel::Closed,
+            active_ticker_browser: None,
         }
     }
 
@@ -195,8 +214,63 @@ impl Dashboard {
                     );
                 }
             },
+            Message::OpenTickerBrowser => {
+                let (table, task) = tickers_table::TickersTable::new(vec![]);
+                self.right_panel = RightPanel::TickerBrowser(table);
+                return (task.map(Message::TickerBrowser), None);
+            }
+            Message::OpenPaneSettings(window, pane) => {
+                self.right_panel = RightPanel::Settings { window, pane };
+            }
+            Message::CloseRightPanel => {
+                self.right_panel = RightPanel::Closed;
+            }
+            Message::TickerBrowser(msg) => {
+                if let RightPanel::TickerBrowser(ref mut table) = self.right_panel {
+                    match table.update(msg) {
+                        Some(tickers_table::Action::TickerSelected(ti, ex, content)) => {
+                            let task = self.init_pane_task(main_window.id, ti, ex, &content);
+                            return (task, None);
+                        }
+                        Some(tickers_table::Action::Fetch(task)) => {
+                            return (task.map(Message::TickerBrowser), None);
+                        }
+                        Some(tickers_table::Action::ErrorOccurred(err)) => {
+                            return (Task::done(Message::Notification(Toast::error(err.to_string()))), None);
+                        }
+                        None => {}
+                    }
+                }
+            }
             Message::Pane(window, message) => {
                 match message {
+                    pane::Message::TickerBrowser(pane, msg) => {
+                        if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
+                            if let Some(table) = pane_state.ticker_browser.as_mut() {
+                                match table.update(msg) {
+                                    Some(tickers_table::Action::TickerSelected(ti, ex, content)) => {
+                                        // Close the browser but keep StreamModifier open
+                                        pane_state.ticker_browser = None;
+                                        pane_state.modal = None;
+                                        self.active_ticker_browser = None;
+                                        let task = self.init_pane_task(main_window.id, ti, ex, &content);
+                                        return (task, None);
+                                    }
+                                    Some(tickers_table::Action::Fetch(task)) => {
+                                        let target_pane = pane;
+                                        return (
+                                            task.map(move |m| Message::Pane(window, pane::Message::TickerBrowser(target_pane, m))),
+                                            None,
+                                        );
+                                    }
+                                    Some(tickers_table::Action::ErrorOccurred(err)) => {
+                                        return (Task::done(Message::Notification(Toast::error(err.to_string()))), None);
+                                    }
+                                    None => {}
+                                }
+                            }
+                        }
+                    }
                     pane::Message::PaneClicked(pane) => {
                         self.focus = Some((window, pane));
                     }
@@ -253,10 +327,47 @@ impl Dashboard {
 
                         return (Task::done(Message::RefreshStreams), None);
                     }
+                    pane::Message::OpenSettingsPanel(pane) => {
+                        self.right_panel = RightPanel::Settings { window, pane };
+                    }
+                    pane::Message::OpenTickerBrowser(pane) => {
+                        // Close any active browser before opening a new one
+                        if let Some((w, p)) = self.active_ticker_browser.take() {
+                            if let Some(ps) = self.get_mut_pane(main_window.id, w, p) {
+                                ps.modal = None;
+                            }
+                        }
+
+                        if let Some(state) = self.get_mut_pane(main_window.id, window, pane) {
+                            if state.ticker_browser.is_none() {
+                                let (table, task) = tickers_table::TickersTable::new(vec![]);
+                                state.ticker_browser = Some(table);
+                                let target_pane = pane;
+                                if let Some(ps) = self.get_mut_pane(main_window.id, window, pane) {
+                                    ps.modal = Some(pane::Modal::TickerBrowser);
+                                }
+                                self.active_ticker_browser = Some((window, pane));
+                                return (
+                                    task.map(move |m| Message::Pane(window, pane::Message::TickerBrowser(target_pane, m))),
+                                    None,
+                                );
+                            } else {
+                                if let Some(ps) = self.get_mut_pane(main_window.id, window, pane) {
+                                    ps.modal = Some(pane::Modal::TickerBrowser);
+                                }
+                                self.active_ticker_browser = Some((window, pane));
+                            }
+                        }
+                    }
+                    // Allow changing chart type from settings panel
+                    // This is triggered via Dashboard::ChangePaneChartType messages
                     pane::Message::ToggleModal(pane, modal_type) => {
                         if let Some(pane) = self.get_mut_pane(main_window.id, window, pane) {
                             if Some(modal_type) == pane.modal {
                                 pane.modal = None;
+                                if matches!(modal_type, pane::Modal::TickerBrowser) {
+                                    self.active_ticker_browser = None;
+                                }
                             } else {
                                 pane.modal = Some(modal_type);
                             }
@@ -479,6 +590,16 @@ impl Dashboard {
                             if let pane::Content::Kline(chart, _) = &mut pane_state.content {
                                 chart.update_study_configurator(msg);
                             }
+                        }
+                    }
+                }
+            }
+            Message::ChangePaneChartType(window, pane, content) => {
+                if let Some(pane_state) = self.get_mut_pane(main_window.id, window, pane) {
+                    if let Some((_ex, _ticker)) = pane_state.stream_pair() {
+                        if let Some(ti) = pane_state.settings.ticker_info {
+                            let task = self.init_pane_task(main_window.id, ti, ti.exchange(), &content);
+                            return (task, None);
                         }
                     }
                 }
@@ -847,8 +968,79 @@ impl Dashboard {
         .spacing(6)
         .style(style::pane_grid)
         .into();
+    
+        let right_view: Option<Element<'_, Message>> = match &self.right_panel {
+            RightPanel::Closed => None,
+            RightPanel::TickerBrowser(table) => {
+                let close_btn = button(crate::style::icon_text(crate::style::Icon::Close, 12))
+                    .on_press(Message::CloseRightPanel)
+                    .style(|theme, status| crate::style::button::transparent(theme, status, false));
 
-        pane_grid.map(move |message| Message::Pane(main_window.id, message))
+                let content = responsive(move |size| table.view(size).map(Message::TickerBrowser));
+
+                let col = iced::widget::column![
+                    iced::widget::row![close_btn].spacing(4),
+                    content,
+                ]
+                .spacing(8);
+
+                Some(container(col).width(Length::Fixed(320.0)).into())
+            }
+            RightPanel::Settings { window, pane } => {
+                let settings_el: Option<Element<'_, Message>> = if let Some(state) = self.get_pane(main_window.id, *window, *pane) {
+                    match &state.content {
+                        pane::Content::Heatmap(chart, _) => {
+                            let el = crate::modal::pane::settings::heatmap_cfg_view(chart.visual_config(), *pane)
+                                .map(move |m| Message::Pane(*window, m));
+                            Some(el)
+                        }
+                        pane::Content::Kline(chart, _) => {
+                            let el = crate::modal::pane::settings::kline_cfg_view(
+                                chart.study_configurator(),
+                                chart.kind(),
+                                *pane,
+                            )
+                            .map(move |m| Message::Pane(*window, m));
+                            Some(el)
+                        }
+                        pane::Content::TimeAndSales(panel) => {
+                            let el = crate::modal::pane::settings::timesales_cfg_view(panel.config, *pane)
+                                .map(move |m| Message::Pane(*window, m));
+                            Some(el)
+                        }
+                        pane::Content::Starter => None,
+                    }
+                } else { None };
+
+                let close_btn = button(crate::style::icon_text(crate::style::Icon::Close, 12))
+                    .on_press(Message::CloseRightPanel)
+                    .style(|theme, status| crate::style::button::transparent(theme, status, false));
+
+                let col = if let Some(content) = settings_el {
+                    iced::widget::column![iced::widget::row![close_btn].spacing(4), content]
+                        .spacing(8)
+                } else {
+                    iced::widget::column![
+                        iced::widget::row![close_btn].spacing(4),
+                        iced::widget::text("No settings available").size(14),
+                    ]
+                    .spacing(8)
+                };
+
+                Some(container(col).width(Length::Fixed(320.0)).into())
+            }
+        };
+
+        if let Some(right) = right_view {
+            row![
+                pane_grid.map(move |message| Message::Pane(main_window.id, message)),
+                right,
+            ]
+            .spacing(8)
+            .into()
+        } else {
+            pane_grid.map(move |message| Message::Pane(main_window.id, message))
+        }
     }
 
     pub fn view_window<'a>(
@@ -858,26 +1050,28 @@ impl Dashboard {
         timezone: UserTimezone,
     ) -> Element<'a, Message> {
         if let Some((state, _)) = self.popout.get(&window) {
-            let content = container(
-                PaneGrid::new(state, |id, pane, _maximized| {
-                    let is_focused = self.focus == Some((window, id));
-                    pane.view(
-                        id,
-                        state.len(),
-                        is_focused,
-                        false,
-                        window,
-                        main_window,
-                        timezone,
-                    )
-                })
-                .on_click(pane::Message::PaneClicked),
-            )
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .padding(8);
+            let pane_grid: Element<_> = PaneGrid::new(state, |id, pane, _maximized| {
+                let is_focused = self.focus == Some((window, id));
+                pane.view(
+                    id,
+                    state.len(),
+                    is_focused,
+                    false,
+                    window,
+                    main_window,
+                    timezone,
+                )
+            })
+            .on_click(pane::Message::PaneClicked)
+            .into();
 
-            Element::new(content).map(move |message| Message::Pane(window, message))
+            let base = container(pane_grid)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .padding(8);
+
+            // Let pane-level view handle any overlays (e.g., TickerBrowser) to avoid duplication
+            Element::new(base).map(move |message| Message::Pane(window, message))
         } else {
             Element::new(center("No pane found for window"))
                 .map(move |message| Message::Pane(window, message))

--- a/src/screen/dashboard/sidebar.rs
+++ b/src/screen/dashboard/sidebar.rs
@@ -9,7 +9,7 @@ use data::sidebar;
 
 use iced::{
     Alignment, Element, Length, Subscription, Task,
-    widget::{responsive, text_input},
+    widget::{text_input},
     widget::{Space, column, row},
 };
 
@@ -96,26 +96,11 @@ impl Sidebar {
             TooltipPosition::Left
         };
 
-        let is_table_open = self.tickers_table.is_open();
+        let nav_buttons = self.nav_buttons(audio_volume, tooltip_position);
 
-        let nav_buttons = self.nav_buttons(is_table_open, audio_volume, tooltip_position);
-
-        let tickers_table = if is_table_open {
-            column![responsive(move |size| self
-                .tickers_table
-                .view(size)
-                .map(Message::TickersTable))]
-            .width(200)
-        } else {
-            column![]
-        };
-
-        match state.position {
-            sidebar::Position::Left => row![nav_buttons, tickers_table],
-            sidebar::Position::Right => row![tickers_table, nav_buttons],
-        }
-        .spacing(if is_table_open { 8 } else { 4 })
-        .into()
+        row![nav_buttons]
+            .spacing(4)
+            .into()
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
@@ -124,7 +109,6 @@ impl Sidebar {
 
     fn nav_buttons(
         &self,
-        is_table_open: bool,
         audio_volume: Option<f32>,
         tooltip_position: TooltipPosition,
     ) -> iced::widget::Column<'_, Message> {
@@ -154,20 +138,6 @@ impl Sidebar {
                 None,
                 tooltip_position,
                 move |theme, status| crate::style::button::transparent(theme, status, is_active),
-            )
-        };
-
-        let ticker_search_button = {
-            button_with_tooltip(
-                icon_text(Icon::Search, 14)
-                    .width(24)
-                    .align_x(Alignment::Center),
-                Message::TickersTable(super::tickers_table::Message::ToggleTable),
-                None,
-                tooltip_position,
-                move |theme, status| {
-                    crate::style::button::transparent(theme, status, is_table_open)
-                },
             )
         };
 
@@ -204,7 +174,6 @@ impl Sidebar {
         };
 
         column![
-            ticker_search_button,
             layout_modal_button,
             audio_btn,
             Space::with_height(Length::Fill),

--- a/src/screen/dashboard/tickers_table.rs
+++ b/src/screen/dashboard/tickers_table.rs
@@ -20,8 +20,10 @@ use iced::{
 const ACTIVE_UPDATE_INTERVAL: u64 = 25;
 const INACTIVE_UPDATE_INTERVAL: u64 = 300;
 
-const TICKER_CARD_HEIGHT: f32 = 64.0;
-const SEARCH_BAR_HEIGHT: f32 = 120.0;
+// Compact browser layout
+const BROWSER_WIDTH: f32 = 360.0;
+const TICKER_CARD_HEIGHT: f32 = 28.0;
+const SEARCH_BAR_HEIGHT: f32 = 64.0;
 
 // Enhanced virtualization constants
 const VISIBLE_BUFFER: f32 = 1.5; // Render 1.5 screens worth of content
@@ -855,10 +857,9 @@ impl TickersTable {
         };
 
         let search_bar_row = row![
-            text_input("Search for a ticker...", &self.normalized_search)
+            text_input("Search all markets", &self.normalized_search)
                 .style(style::search_input)
                 .on_input(|value| {
-                    // Filter out "/" character to prevent it from being entered in search
                     let filtered_value = value.replace("/", "");
                     Message::UpdateSearchQuery(filtered_value)
                 })
@@ -866,7 +867,8 @@ impl TickersTable {
             sorting_button
         ]
         .align_y(Vertical::Center)
-        .spacing(4);
+        .spacing(4)
+        .height(Length::Fixed(SEARCH_BAR_HEIGHT));
 
         let sort_options_column = {
             // Only show market filters for exchanges that support them
@@ -1026,10 +1028,10 @@ impl TickersTable {
             .spacing(4)
         };
 
-        let mut content = column![search_bar_row,]
+        let mut content = column![search_bar_row]
             .spacing(8)
-            .padding(padding::right(8))
-            .width(Length::Fill);
+            .padding(padding::right(4).left(4))
+            .width(Length::Fixed(BROWSER_WIDTH));
 
         if self.show_sort_options {
             content = content.push(sort_options_column);
@@ -1060,14 +1062,26 @@ impl TickersTable {
 
         content = content.push(ticker_cards);
 
-        scrollable::Scrollable::with_direction(
-            content,
-            scrollable::Direction::Vertical(
-                scrollable::Scrollbar::new().width(8).scroller_width(6),
-            ),
+        container(
+            scrollable::Scrollable::with_direction(
+                content,
+                scrollable::Direction::Vertical(
+                    scrollable::Scrollbar::new().width(8).scroller_width(6),
+                ),
+            )
+            .on_scroll(Message::Scrolled)
+            .style(style::scroll_bar)
         )
-        .on_scroll(Message::Scrolled)
-        .style(style::scroll_bar)
+        .width(Length::Fixed(BROWSER_WIDTH))
+        .height(Length::Fill)
+        .style(|theme: &Theme| {
+            let palette = theme.extended_palette();
+            iced::widget::container::Style {
+                background: Some(iced::Background::Color(palette.background.base.color.scale_alpha(0.95))),
+                text_color: Some(palette.background.base.text),
+                ..Default::default()
+            }
+        })
         .into()
     }
 


### PR DESCRIPTION

<img width="711" height="583" alt="Screenshot 2025-09-06 at 4 21 28 PM" src="https://github.com/user-attachments/assets/d89870a3-62e0-491f-b76a-60c94df73989" />

- Introduced floating UI for ticker browser for users to select any ticker directly into a pane
- Implement state management for the right panel, including handling messages for opening and closing the Ticker Browser and Settings.
- Update the Dashboard view to conditionally render the right panel based on its state.
- Refactor pane handling to support new modal interactions and improve user experience with ticker selection and settings adjustments.